### PR TITLE
Remove appraisal runtime dependency

### DIFF
--- a/country_select.gemspec
+++ b/country_select.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   # specify any dependencies here; for example:
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'actionpack'
-  s.add_runtime_dependency 'appraisal'
+  s.add_development_dependency 'appraisal'
 end


### PR DESCRIPTION
I think appraisal should be a development dependency, right?
