### PR TITLE
Renamed Ivory Coast

### DIFF
--- a/lib/country_select/countries.rb
+++ b/lib/country_select/countries.rb
@@ -55,7 +55,7 @@ module CountrySelect
     "cd" => "Congo, the Democratic Republic of the",
     "ck" => "Cook Islands",
     "cr" => "Costa Rica",
-    "ci" => "Côte d'Ivoire",
+    "ci" => "Ivory Coast",
     "hr" => "Croatia",
     "cu" => "Cuba",
     "cw" => "Curaçao",


### PR DESCRIPTION
My bad :)

Only Ivory Coast needed to be translated to English in the end.

I also noticed that lots of French departments are in the list, they're not countries, is that alright? Same for Åland Islands (part of Sweden) and other territories. I'm asking cause it's a slippery slope, even though I guess the point is not to get political.

You mentioned internationalization earlier, what would be the process exactly? I'm more than willing to provide both English and French translations for the list of countries. We'll most likely end up using them at work anyway.
