### PR TITLE
Added Zimbabwe/ZW

### DIFF
--- a/lib/country_select/countries.rb
+++ b/lib/country_select/countries.rb
@@ -249,6 +249,7 @@ module CountrySelect
     "eh" => "Western Sahara",
     "ye" => "Yemen",
     "zm" => "Zambia",
+    "zw" => "Zimbabwe"
   } unless const_defined?("COUNTRIES")
 
   ISO_COUNTRIES_FOR_SELECT = COUNTRIES.invert unless const_defined?("ISO_COUNTRIES_FOR_SELECT")


### PR DESCRIPTION
Zimbabwe is on the https://en.wikipedia.org/wiki/ISO_3166-1 list, yet it disappeared here
