### PR TITLE
Use namespaced countries gem in order to not pollute namespace.

### DIFF
--- a/lib/country_select/countries.rb
+++ b/lib/country_select/countries.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require 'countries'
+require 'iso3166'
 
 module CountrySelect
   def self.use_iso_codes
@@ -21,7 +21,7 @@ module CountrySelect
     ISO3166::Country.all.inject({}) do |hash,country_pair|
       default_name = country_pair.first
       code = country_pair.last
-      country = Country.new(code)
+      country = ISO3166::Country.new(code)
       localized_name = country.translations[with_locale.to_s]
 
       # Codes should not be downcased, but they were previous to 1.3


### PR DESCRIPTION
Hey,

I use this gem inside a project that already has a model called `Country` which leads to a namespace collision. The `countries` gem already supports being within it's own namespace but the `country_select` gem does import the non-namespaced version. This PR uses the namespaces version, which should work just like the old version.
