### PR TITLE
Update README.me for country priority listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ country_select("user", "country")
 Supplying priority countries to be placed at the top of the list:
 
 ```ruby
-country_select("user", "country", priority_countries: ["GB", "FR", "DE"])
+country_select("user", "country", ["GB", "FR", "DE"])
 ```
 
 Supplying only certain countries:
@@ -48,7 +48,7 @@ country_select("user", "country", only: ["GB", "FR", "DE"])
 Supplying additional html options:
 
 ```ruby
-country_select("user", "country", { priority_countries: ["GB", "FR"] }, { selected: "GB", class: 'form-control' })
+country_select("user", "country", ["GB", "FR"], { selected: "GB", class: 'form-control' })
 ```
 
 ### ISO 3166-1 alpha-2 codes


### PR DESCRIPTION
Using the `priority_countries` key will only list the keys:

![bildschirmfoto vom 2014-05-04 12 55 14](https://cloud.githubusercontent.com/assets/164400/2872836/37d5ac44-d37b-11e3-998b-1bdf9147057e.png)

This might be a regression as the method's signature suggests a hash as the 3rd argument.
