### PR TITLE
Discard countries from options with :except

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Supplying only certain countries:
 country_select("user", "country", only: ["GB", "FR", "DE"])
 ```
 
+Discarding certain countries:
+
+```ruby
+country_select("user", "country", except: ["GB", "FR", "DE"])
+```
+
 Supplying additional html options:
 
 ```ruby

--- a/lib/country_select/tag_helper.rb
+++ b/lib/country_select/tag_helper.rb
@@ -39,6 +39,10 @@ module CountrySelect
       @options[:only]
     end
 
+    def except_country_codes
+      @options[:except]
+    end
+
     def country_options
       country_options_for(all_country_codes, true)
     end
@@ -48,6 +52,8 @@ module CountrySelect
 
       if only_country_codes.present?
         codes & only_country_codes
+      elsif except_country_codes.present?
+        codes - except_country_codes
       else
         codes
       end

--- a/spec/country_select_spec.rb
+++ b/spec/country_select_spec.rb
@@ -91,4 +91,11 @@ describe "CountrySelect" do
     t = builder.country_select(:country_code, only: ['DK','DE'])
     expect(t).to eql(tag)
   end
+
+  it "discards some countries" do
+    tag = options_for_select([["United States of America", "US"]])
+    walrus.country_code = 'DE'
+    t = builder.country_select(:country_code, except: ['US'])
+    expect(t).to_not include(tag)
+  end
 end


### PR DESCRIPTION
This addresses the issue https://github.com/stefanpenner/country_select/issues/60.
I also encountered the need for this feature.  Basically you use the :except option as you would with the :only one, which have the effect of removing some countries from the selection.

What do you think?
