### PR TITLE
Rails 3.2 prompt and include_blank support

### DIFF
--- a/lib/country_select/rails3/country_select_helper.rb
+++ b/lib/country_select/rails3/country_select_helper.rb
@@ -31,7 +31,7 @@ module ActionView
         else
           html_options = @html_options.stringify_keys
           add_default_name_and_id(html_options)
-          content_tag(:select, country_option_tags, html_options)
+          content_tag(:select, add_options(country_option_tags, options, value(object)), html_options)
         end
       end
     end

--- a/spec/country_select_spec.rb
+++ b/spec/country_select_spec.rb
@@ -151,5 +151,17 @@ describe "CountrySelect" do
         builder.country_select(:country_code, country_names)
       end.to raise_error(CountrySelect::CountryNotFoundError, error_msg)
     end
+
+    it "supports the select prompt" do
+      tag = '<option value="">Select your country</option>'
+      t = builder.country_select(:country_code, prompt: 'Select your country')
+      expect(t).to include(tag)
+    end
+
+    it "supports the include_blank option" do
+      tag = '<option value=""></option>'
+      t = builder.country_select(:country_code, include_blank: true)
+      expect(t).to include(tag)
+    end
   end
 end


### PR DESCRIPTION
This correctly allows use of `select` specific options such as `prompt` and `include_blank` in Rails 3.2

Fixes #71
