### PR TITLE
Sort unicode characters; fixes issue #78

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     country_select (2.1.0)
       countries (~> 0.9, >= 0.9.3)
+      sort_alphabetical
 
 GEM
   remote: https://rubygems.org/
@@ -263,12 +264,15 @@ GEM
     rubysl-yaml (2.0.4)
     rubysl-zlib (2.0.1)
     slop (3.6.0)
+    sort_alphabetical (1.0.1)
+      unicode_utils (>= 1.2.2)
     sprockets (2.2.2)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
     tilt (1.4.1)
+    unicode_utils (1.4.0)
     wwtd (0.5.5)
 
 PLATFORMS

--- a/country_select.gemspec
+++ b/country_select.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'wwtd'
 
   s.add_dependency 'countries', '~> 0.9', '>= 0.9.3'
+  s.add_dependency 'sort_alphabetical'
 end

--- a/lib/country_select/tag_helper.rb
+++ b/lib/country_select/tag_helper.rb
@@ -84,7 +84,13 @@ module CountrySelect
 
           [name,code]
         end
-        sorted ? country_list.sort : country_list
+
+        if sorted
+            require 'sort_alphabetical'
+            next country_list.sort_alphabetical
+        else
+            next country_list
+        end
       end
     end
 

--- a/spec/country_select_spec.rb
+++ b/spec/country_select_spec.rb
@@ -165,6 +165,12 @@ describe "CountrySelect" do
     end
   end
 
+  it 'sorts unicode' do
+    tag = builder.country_select(:country_code, only: ['AX', 'AL', 'AF', 'ZW'])
+    order = tag.scan(/value="(\w{2})"/).map { |o| o[0] }
+    expect(order).to eq(['AF', 'AX', 'AL', 'ZW'])
+  end
+
   describe "custom formats" do
     it "accepts a custom formatter" do
       ::CountrySelect::FORMATS[:with_alpha2] = lambda do |country|


### PR DESCRIPTION
If you don't want any additional dependencies, another solution is to use:

```
country_list.sort do |a, b|
  ActiveSupport::Inflector.transliterate(a[0]) <=> ActiveSupport::Inflector.transliterate(b[0])
end
```

This is not quite correct though, since Å is supposed to be sorted between A and B, and not equal to A (but it is "good enough" for this purpose, I suppose).