### PR TITLE
Don't re-instantiate the country object if not required

### DIFF
--- a/lib/country_select/tag_helper.rb
+++ b/lib/country_select/tag_helper.rb
@@ -73,7 +73,7 @@ module CountrySelect
             code = country.first
           end
 
-          country = ISO3166::Country.new(code)
+          country = ISO3166::Country.new(code) unless country.kind_of?(ISO3166::Country)
 
           unless country.present?
             msg = "Could not find Country with string '#{code_or_name}'"

--- a/lib/country_select/tag_helper.rb
+++ b/lib/country_select/tag_helper.rb
@@ -71,9 +71,8 @@ module CountrySelect
             code = country.alpha2
           elsif country = ISO3166::Country.find_by_name(code_or_name)
             code = country.first
+            country = ISO3166::Country.new(code)
           end
-
-          country = ISO3166::Country.new(code) unless country.kind_of?(ISO3166::Country)
 
           unless country.present?
             msg = "Could not find Country with string '#{code_or_name}'"


### PR DESCRIPTION
This is a small performance improvement, we don't need to re-instantiate a county object if already looked up at line 70

```
if country = ISO3166::Country.new(code_or_name)
```

PS: ```ISO3166::Country.new``` creates new instances every time:

````
irb(main):004:0> ISO3166::Country.new('IT').object_id
=> 70160945975800
irb(main):005:0> ISO3166::Country.new('IT').object_id
=> 70160945381520
````