### PR TITLE
Triage poor performance by preventing usage of countries gem v0.10.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     country_select (2.1.0)
-      countries (~> 0.9, >= 0.9.3)
+      countries (>= 0.9.3, < 0.10.0)
 
 GEM
   remote: https://rubygems.org/

--- a/country_select.gemspec
+++ b/country_select.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'wwtd'
 
-  s.add_dependency 'countries', '~> 0.9', '>= 0.9.3'
+  s.add_dependency 'countries', '>= 0.9.3', '< 0.10.0'
 end


### PR DESCRIPTION
This is meant to be a temporary fix until countries v0.10.1 is released and can be integrated into country_select.