### PR TITLE
Mark priority countries as selected only once

### DIFF
--- a/lib/country_select/tag_helper.rb
+++ b/lib/country_select/tag_helper.rb
@@ -13,7 +13,7 @@ module CountrySelect
         option_tags = options_for_select(priority_countries_options, option_tags_options)
         option_tags += html_safe_newline + options_for_select([priority_countries_divider], disabled: priority_countries_divider)
 
-        if priority_countries.include?(option_tags_options[:selected])
+        if priority_countries_options.map(&:second).include?(option_tags_options[:selected])
           option_tags_options[:selected] = nil
         end
 
@@ -86,7 +86,7 @@ module CountrySelect
           else
             [formatted_country, code]
           end
-          
+
         end
 
         if sorted

--- a/spec/country_select_spec.rb
+++ b/spec/country_select_spec.rb
@@ -206,5 +206,15 @@ describe "CountrySelect" do
       expect(t).to include(tag)
     end
 
+    it "marks priority countries as selected only once" do
+      ::CountrySelect::FORMATS[:with_alpha3] = lambda do |country|
+        [country.name, country.alpha3]
+      end
+
+      tag = options_for_select([['United States', 'USA']], 'USA')
+      walrus.country_code = 'USA'
+      t = builder.country_select(:country_code, format: :with_alpha3, priority_countries: ['US'])
+      expect(t.scan(Regexp.new(Regexp.escape(tag))).size).to eq 1
+    end
   end
 end


### PR DESCRIPTION
This patch checks whether any of the priority countries options' `value`s were `selected` (instead of whether any of the priority countries `alpha2`s' were `selected`.)  This prevents priority country from being marked as selected twice when using a custom array-style formatter.