### PR TITLE
Make sort_alphabetical opt-in

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     country_select (2.5.2)
       countries (~> 1.2.0)
-      sort_alphabetical (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -287,6 +286,7 @@ DEPENDENCIES
   rake
   rspec (~> 3)
   rubysl (~> 2.0)
+  sort_alphabetical (~> 1.0)
   wwtd
 
 BUNDLED WITH

--- a/country_select.gemspec
+++ b/country_select.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'wwtd'
+  s.add_development_dependency 'sort_alphabetical', '~> 1.0'
 
   s.add_dependency 'countries', '~> 1.2.0'
-  s.add_dependency 'sort_alphabetical', '~> 1.0'
 end

--- a/lib/country_select.rb
+++ b/lib/country_select.rb
@@ -1,7 +1,11 @@
 # encoding: utf-8
 
 require 'countries'
-require 'sort_alphabetical'
+
+begin
+  require 'sort_alphabetical'
+rescue LoadError
+end
 
 require 'country_select/version'
 require 'country_select/formats'

--- a/lib/country_select/tag_helper.rb
+++ b/lib/country_select/tag_helper.rb
@@ -89,7 +89,11 @@ module CountrySelect
         end
 
         if sorted
-          country_list.sort_alphabetical
+          if defined?(::SortAlphabetical)
+            country_list.sort_alphabetical
+          else
+            country_list.sort
+          end
         else
           country_list
         end

--- a/spec/country_select_spec.rb
+++ b/spec/country_select_spec.rb
@@ -177,10 +177,17 @@ describe "CountrySelect" do
     end
   end
 
-  it 'sorts unicode' do
+  it 'sorts unicode if sort_alphabetical is present' do
     tag = builder.country_select(:country_code, only: ['AX', 'AL', 'AF', 'ZW'])
     order = tag.scan(/value="(\w{2})"/).map { |o| o[0] }
     expect(order).to eq(['AF', 'AX', 'AL', 'ZW'])
+  end
+
+  it 'falls back to regular sort if sort_alphabetical was not loaded' do
+    hide_const("SortAlphabetical")
+    tag = builder.country_select(:country_code, only: ['AX', 'AL', 'AF', 'ZW'])
+    order = tag.scan(/value="(\w{2})"/).map { |o| o[0] }
+    expect(order).to eq(['AF', 'AL', 'ZW', 'AX'])
   end
 
   describe "custom formats" do


### PR DESCRIPTION
This is a fix for #128, and still a work-in-progress. I differs from the approach proposed in #128, because the dependencies would still be installed if they remain in the gemspec. I'd like to prevent that.

If it stays like this, there needs to be a prominent note in the README informing users to add `sort_alphabetical` to their Gemfile if they want to keep the current behavior.
