### PR TITLE
Explicitly specify latest version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ gem install country_select
 Or put the following in your Gemfile
 
 ```ruby
-gem 'country_select'
+gem 'country_select', '~> 3.1'
 ```
 
 If you don't want to require `sort_alphabetical` (it depends on `unicode_utils` which is known to use lots of memory) you can opt out of using it as follows:


### PR DESCRIPTION
It appears that bundler may not always install the latest gem version if you leave the version unspecified. This doesn't address the root cause in #155, but hopefully prevents confusion in the future.

Closes #155