### PR TITLE
Remove deprecated rubyforge_project  from gemspec

### DIFF
--- a/country_select.gemspec
+++ b/country_select.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{Country Select Plugin}
   s.description = %q{Provides a simple helper to get an HTML select list of countries.  The list of countries comes from the ISO 3166 standard.  While it is a relatively neutral source of country names, it will still offend some users.}
 
-  s.rubyforge_project = 'country_select'
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
RubyForge was close more than 5 years ago from what I can tell.