### PR TITLE
Safely dig into country translations

### DIFF
--- a/lib/country_select/formats.rb
+++ b/lib/country_select/formats.rb
@@ -2,6 +2,6 @@ module CountrySelect
   FORMATS = {}
 
   FORMATS[:default] = lambda do |country|
-    country.translations[I18n.locale.to_s] || country.name
+    country.translations&.dig(I18n.locale.to_s) || country.name
   end
 end


### PR DESCRIPTION
I sometimes have this error : 
```
NoMethodError: undefined method `[]' for nil:NilClass
File /app/vendor/bundle/ruby/2.5.0/gems/country_select-4.0.0/lib/country_select/formats.rb line 5 in block in <module:CountrySelect>
```

I don't know why, but it happens that the translations are not correctly loaded and **country.translations** is **nil**