### PR TITLE
Allow value flipping via value_as: :name

### DIFF
--- a/lib/country_select/tag_helper.rb
+++ b/lib/country_select/tag_helper.rb
@@ -38,6 +38,10 @@ module CountrySelect
       @options[:locale]
     end
 
+    def value_as
+      @options[:value_as]
+    end
+
     def priority_countries
       @options[:priority_countries]
     end
@@ -94,7 +98,11 @@ module CountrySelect
           if formatted_country.is_a?(Array)
             formatted_country
           else
-            [formatted_country, code]
+            if(value_as == :name)
+              [formatted_country, formatted_country]
+            else
+              [formatted_country, code]
+            end
           end
 
         end


### PR DESCRIPTION
Lets you choose what you would like the value as, the default behaviour or override via `value_as: :name`