### PR TITLE
README: Update CI badge to point to default branch only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rails – Country Select
-[![Build Status](https://travis-ci.org/stefanpenner/country_select.svg)](https://travis-ci.org/stefanpenner/country_select)
+[![Build Status](https://travis-ci.org/stefanpenner/country_select.svg?branch=master)](https://travis-ci.org/stefanpenner/country_select)
 
 Provides a simple helper to get an HTML select list of countries using the
 [ISO 3166-1 standard](https://en.wikipedia.org/wiki/ISO_3166-1).


### PR DESCRIPTION
This changes the badge to the stefanpenner/country_select one, but only the `master` branch.