### PR TITLE
Fix i18n fallback in country translations

### DIFF
--- a/lib/country_select/formats.rb
+++ b/lib/country_select/formats.rb
@@ -2,6 +2,8 @@ module CountrySelect
   FORMATS = {}
 
   FORMATS[:default] = lambda do |country|
-    country.translations&.dig(I18n.locale.to_s) || country.name
+    # Need to use :[] specifically, not :dig, because country.translations is a
+    # ISO3166::Translations object, which overrides :[] to support i18n locale fallbacks
+    country.translations&.send(:[], I18n.locale.to_s) || country.name
   end
 end

--- a/spec/country_select_spec.rb
+++ b/spec/country_select_spec.rb
@@ -61,6 +61,23 @@ describe "CountrySelect" do
     end
   end
 
+  it 'falls back when given a country-specific locale' do
+    I18n.available_locales = [:en, :de, :'de-AT']
+    ISO3166.reset
+
+    tag = options_for_select([['Deutschland', 'DE']], 'DE')
+
+    walrus.country_code = 'DE'
+    original_locale = I18n.locale
+    begin
+      I18n.locale = :'de-AT'
+      t = builder.country_select(:country_code)
+      expect(t).to include(tag)
+    ensure
+      I18n.locale = original_locale
+    end
+  end
+
   it "accepts a locale option" do
     I18n.available_locales = [:fr]
     ISO3166.reset


### PR DESCRIPTION
This fixes an issue inadvertently introduced in version 5.0.0 by https://github.com/stefanpenner/country_select/pull/173.

In locales like `en-US` or `de-CH`, with version 5.0.0 we started seeing the ISO names instead of the common names in our country dropdowns. This PR fixes the default format so that fallbacks work correctly, while preserving the handling of nil/missing translations.