### PR TITLE
Update countries gem to 4.0+.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     country_select (5.1.0)
-      countries (~> 3.0)
+      countries (~> 4.0)
       sort_alphabetical (~> 1.1)
 
 GEM
@@ -30,16 +30,15 @@ GEM
     builder (3.2.4)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
-    countries (3.1.0)
-      i18n_data (~> 0.11.0)
+    countries (4.0.0)
+      i18n_data (~> 0.13.0)
       sixarm_ruby_unaccent (~> 1.1)
-      unicode_utils (~> 1.4)
     crass (1.0.6)
     diff-lcs (1.4.4)
     erubi (1.10.0)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
-    i18n_data (0.11.0)
+    i18n_data (0.13.0)
     loofah (2.9.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -96,4 +95,4 @@ DEPENDENCIES
   wwtd (~> 1)
 
 BUNDLED WITH
-   2.2.13
+   2.2.15

--- a/country_select.gemspec
+++ b/country_select.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'wwtd', '~> 1'
 
-  s.add_dependency 'countries', '~> 3.0'
+  s.add_dependency 'countries', '~> 4.0'
   s.add_dependency 'sort_alphabetical', '~> 1.1'
 end

--- a/gemfiles/actionpack.edge.gemfile.lock
+++ b/gemfiles/actionpack.edge.gemfile.lock
@@ -26,7 +26,7 @@ PATH
   remote: ..
   specs:
     country_select (5.1.0)
-      countries (~> 3.0)
+      countries (~> 4.0)
       sort_alphabetical (~> 1.1)
 
 GEM
@@ -35,16 +35,15 @@ GEM
     builder (3.2.4)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
-    countries (3.1.0)
-      i18n_data (~> 0.11.0)
+    countries (4.0.0)
+      i18n_data (~> 0.13.0)
       sixarm_ruby_unaccent (~> 1.1)
-      unicode_utils (~> 1.4)
     crass (1.0.6)
     diff-lcs (1.4.4)
     erubi (1.10.0)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
-    i18n_data (0.11.0)
+    i18n_data (0.13.0)
     loofah (2.9.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -103,4 +102,4 @@ DEPENDENCIES
   wwtd (~> 1)
 
 BUNDLED WITH
-   2.2.13
+   2.2.15

--- a/gemfiles/actionpack5.2.gemfile.lock
+++ b/gemfiles/actionpack5.2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     country_select (5.1.0)
-      countries (~> 3.0)
+      countries (~> 4.0)
       sort_alphabetical (~> 1.1)
 
 GEM
@@ -29,16 +29,15 @@ GEM
     builder (3.2.4)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
-    countries (3.1.0)
-      i18n_data (~> 0.11.0)
+    countries (4.0.0)
+      i18n_data (~> 0.13.0)
       sixarm_ruby_unaccent (~> 1.1)
-      unicode_utils (~> 1.4)
     crass (1.0.6)
     diff-lcs (1.4.4)
     erubi (1.10.0)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
-    i18n_data (0.11.0)
+    i18n_data (0.13.0)
     loofah (2.9.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -103,4 +102,4 @@ DEPENDENCIES
   wwtd (~> 1)
 
 BUNDLED WITH
-   2.2.13
+   2.2.15

--- a/gemfiles/actionpack6.0.gemfile.lock
+++ b/gemfiles/actionpack6.0.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     country_select (5.1.0)
-      countries (~> 3.0)
+      countries (~> 4.0)
       sort_alphabetical (~> 1.1)
 
 GEM
@@ -30,16 +30,15 @@ GEM
     builder (3.2.4)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
-    countries (3.1.0)
-      i18n_data (~> 0.11.0)
+    countries (4.0.0)
+      i18n_data (~> 0.13.0)
       sixarm_ruby_unaccent (~> 1.1)
-      unicode_utils (~> 1.4)
     crass (1.0.6)
     diff-lcs (1.4.4)
     erubi (1.10.0)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
-    i18n_data (0.11.0)
+    i18n_data (0.13.0)
     loofah (2.9.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -105,4 +104,4 @@ DEPENDENCIES
   wwtd (~> 1)
 
 BUNDLED WITH
-   2.2.13
+   2.2.15

--- a/gemfiles/actionpack6.1.gemfile.lock
+++ b/gemfiles/actionpack6.1.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     country_select (5.1.0)
-      countries (~> 3.0)
+      countries (~> 4.0)
       sort_alphabetical (~> 1.1)
 
 GEM
@@ -30,16 +30,15 @@ GEM
     builder (3.2.4)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
-    countries (3.1.0)
-      i18n_data (~> 0.11.0)
+    countries (4.0.0)
+      i18n_data (~> 0.13.0)
       sixarm_ruby_unaccent (~> 1.1)
-      unicode_utils (~> 1.4)
     crass (1.0.6)
     diff-lcs (1.4.4)
     erubi (1.10.0)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
-    i18n_data (0.11.0)
+    i18n_data (0.13.0)
     loofah (2.9.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -104,4 +103,4 @@ DEPENDENCIES
   wwtd (~> 1)
 
 BUNDLED WITH
-   2.2.13
+   2.2.15


### PR DESCRIPTION
v4.0.0 was just released, dropping support for Ruby versions older than 2.5 and bumping i18n-data to the latest version