### PR TITLE
Update 'countries' dependency to 4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,19 +95,19 @@ country_select("user", "country", { priority_countries: ["GB", "FR"], selected: 
 ### Using a custom formatter
 
 You can define a custom formatter which will receive an
-[`ISO3166::Country`](https://github.com/hexorx/countries/blob/master/lib/countries/country.rb)
+[`ISO3166::Country`](https://github.com/countries/countries/blob/master/lib/countries/country.rb)
 ```ruby
 # config/initializers/country_select.rb
 
 # Return a string to customize the text in the <option> tag, `value` attribute will remain unchanged
 CountrySelect::FORMATS[:with_alpha2] = lambda do |country|
-  "#{country.name} (#{country.alpha2})"
+  "#{country.iso_short_name} (#{country.alpha2})"
 end
 
 # Return an array to customize <option> text, `value` and other HTML attributes
 CountrySelect::FORMATS[:with_data_attrs] = lambda do |country|
   [
-    country.name,
+    country.iso_short_name,
     country.alpha2,
     {
       'data-country-code' => country.country_code,
@@ -142,7 +142,7 @@ names as display strings. For example, the United States would appear as
 
 Country names are automatically localized based on the value of
 `I18n.locale` thanks to the wonderful
-[countries gem](https://github.com/hexorx/countries/).
+[countries gem](https://github.com/countries/countries/).
 
 Current translations include:
 
@@ -177,7 +177,7 @@ class User < ActiveRecord::Base
   # (usually English) name if no translation is available
   def country_name
     country = ISO3166::Country[country_code]
-    country.translations[I18n.locale.to_s] || country.name
+    country.translations[I18n.locale.to_s] || country.iso_short_name
   end
 
 end

--- a/country_select.gemspec
+++ b/country_select.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'wwtd', '~> 1'
 
-  s.add_dependency 'countries', '~> 4.0'
+  s.add_dependency 'countries', '~> 4.2'
   s.add_dependency 'sort_alphabetical', '~> 1.1'
 end

--- a/lib/country_select/formats.rb
+++ b/lib/country_select/formats.rb
@@ -4,6 +4,6 @@ module CountrySelect
   FORMATS[:default] = lambda do |country|
     # Need to use :[] specifically, not :dig, because country.translations is a
     # ISO3166::Translations object, which overrides :[] to support i18n locale fallbacks
-    country.translations&.send(:[], I18n.locale.to_s) || country.name
+    country.translations&.send(:[], I18n.locale.to_s) || country.iso_short_name
   end
 end

--- a/spec/country_select_spec.rb
+++ b/spec/country_select_spec.rb
@@ -255,7 +255,7 @@ describe "CountrySelect" do
   describe "custom formats" do
     it "accepts a custom formatter" do
       ::CountrySelect::FORMATS[:with_alpha2] = lambda do |country|
-        "#{country.name} (#{country.alpha2})"
+        "#{country.iso_short_name} (#{country.alpha2})"
       end
 
       tag = options_for_select([['United States of America (US)', 'US']], 'US')
@@ -267,7 +267,7 @@ describe "CountrySelect" do
 
     it "accepts an array for formatter" do
       ::CountrySelect::FORMATS[:with_alpha3] = lambda do |country|
-        [country.name, country.alpha3]
+        [country.iso_short_name, country.alpha3]
       end
 
       tag = options_for_select([['United States of America', 'USA']], 'USA')
@@ -278,7 +278,7 @@ describe "CountrySelect" do
 
     it "accepts an array for formatter + custom formatter" do
       ::CountrySelect::FORMATS[:with_alpha3] = lambda do |country|
-        ["#{country.name} (#{country.alpha2})", country.alpha3]
+        ["#{country.iso_short_name} (#{country.alpha2})", country.alpha3]
       end
 
       tag = options_for_select([['United States of America (US)', 'USA']], 'USA')
@@ -289,7 +289,7 @@ describe "CountrySelect" do
 
     it "marks priority countries as selected only once" do
       ::CountrySelect::FORMATS[:with_alpha3] = lambda do |country|
-        [country.name, country.alpha3]
+        [country.iso_short_name, country.alpha3]
       end
 
       tag = options_for_select([['United States of America', 'USA']], 'USA')


### PR DESCRIPTION
Latest release [4.2.0](https://github.com/countries/countries/releases/tag/v4.2.0) of gem includes some deprecations.

This PR updates the dependency to 4.2 and replaces references to deprecated `#name `method with` #iso_short_name`

Also updates references to the gem's repo, that has since moved.