### PR TITLE
Removes DEPRECATION WARNING: find_by_name

### DIFF
--- a/lib/country_select/tag_helper.rb
+++ b/lib/country_select/tag_helper.rb
@@ -79,7 +79,7 @@ module CountrySelect
         country_list = country_codes.map do |code_or_name|
           if country = ISO3166::Country.new(code_or_name)
             code = country.alpha2
-          elsif country = ISO3166::Country.find_by_name(code_or_name)
+          elsif country = ISO3166::Country.find_by_unofficial_names(code_or_name)
             code = country.first
             country = ISO3166::Country.new(code)
           end


### PR DESCRIPTION
  Replace find_by_name with find_by_unofficial_names per recommendation from gem Countries version 5.x